### PR TITLE
Fix streamlit watcher error with torch.classes

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,17 @@ from src.ui.pages import URLMatchingApp
 from src.core.pipeline import URLMatchingPipeline
 from config.settings import AppConfig
 
+# Work around Streamlit's module watcher error when inspecting torch.classes
+try:
+    import torch
+    from types import SimpleNamespace
+
+    if hasattr(torch, "classes") and not hasattr(torch.classes, "__path__"):
+        torch.classes.__path__ = SimpleNamespace(_path=[])
+except Exception:
+    # torch may not be installed or not needed; ignore any issues
+    pass
+
 def main():
     """Main Streamlit application entry point."""
     st.set_page_config(


### PR DESCRIPTION
## Summary
- patch main entry point to handle streamlit watching torch.classes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858a24b674c8321a66e9c8ba3305329